### PR TITLE
add support for deaktivation from hostlook which slow down page load.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.kateproject*
+dmarcts-report-viewer-config.php

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download the required files:
 git clone https://github.com/techsneeze/dmarcts-report-viewer.git
 ```
 
-Once the php files ave been downloaded, you will need to copy `dmarcts-report-viewer-config.php.sample` to `dmarcts-report-viewer-config.php`.  
+Once the php files ave been downloaded, you will need to copy `dmarcts-report-viewer-config.php.sample` to `dmarcts-report-viewer-config.php`.
 
 ```
 cp dmarcts-report-viewer-config.php.sample dmarcts-report-viewer-config.php
@@ -25,6 +25,8 @@ $dbhost="localhost";
 $dbname="dmarc";
 $dbuser="dmarc";
 $dbpass="xxx";
+
+$default_lookup = 1;  # 1= on 0=off (on is old behaviour )
 ```
 
 Ensure that `dmarcts-report-viewer-config.php`, `dmarcts-report-viewer.php`, and `default.css` are in the same folder.

--- a/default.css
+++ b/default.css
@@ -26,7 +26,7 @@ table.reportlist tbody tr:first-child td {
 	font-weight: bold;
 	border-top: 2px solid grey;
 	width: 90%;
-	margin-left: auto; 
+	margin-left: auto;
     margin-right: auto;
 }
 
@@ -67,6 +67,14 @@ table.reportdata tr.yellow {
 	width: 90%;
 	margin: 2em auto 1em auto;
 	padding-top: 10px;
+}
+
+
+.options {
+  font-size: 90%;
+  text-align: right;
+  border: none;
+  width: 90%;
 }
 
 

--- a/dmarcts-report-viewer-config.php.sample
+++ b/dmarcts-report-viewer-config.php.sample
@@ -9,4 +9,6 @@ $dbname="dmarc";
 $dbuser="dmarc";
 $dbpass="xxx";
 
+$default_lookup = 1;  # 1= on 0=off (on is old behaviour )
+
 ?>

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -88,12 +88,12 @@ function tmpl_reportData($reportnumber, $allowed_reports, $host_lookup = 1) {
 
 	if (isset($allowed_reports[BySerial][$reportnumber])) {
 		$row = $allowed_reports[BySerial][$reportnumber];
-		$reportdata[] = "<div class='center reportdesc'><p> Report from ".$row['org']." for ".$row['domain']."<br>(". format_date($row['mindate'], "r" ). " - ".format_date($row['maxdate'], "r" ).")</p></div>";
+    $reportdata[] = "<a id='rpt".$reportnumber."'></a>";
+		$reportdata[] = "<div class='center reportdesc'><p> Report from ".$row['org']." for ".$row['domain']."<br>(". format_date($row['mindate'], "r" ). " - ".format_date($row['maxdate'], "r" ).")<br> Policies: adkim=" . $row[policy_adkim] . ", aspf=" . $row[policy_aspf] .  ", p=" . $row[policy_p] .  ", sp=" . $row[policy_sp] .  ", pct=" . $row[policy_pct] . "</p></div>";
 	} else {
 		return "Unknown report number!";
 	}
 
-	$reportdata[] = "<a id='rpt".$reportnumber."'></a>";
 	$reportdata[] = "<table class='reportdata'>";
 	$reportdata[] = "  <thead>";
 	$reportdata[] = "    <tr>";


### PR DESCRIPTION
Showing report details makes my pages load almost forever, due to time spend in gethostbyaddr($ip). To make the pages load faster I added an option to disable hostlookups per config or by dialog.

The default behavior is to do hostlookups to maintain the old behavior.