### PR TITLE
Bugfix: without period selected, cannot display reports

### DIFF
--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -87,7 +87,7 @@ function tmpl_reportList($allowed_reports, $host_lookup = 1, $sort_order, $dom_s
       . ( $sort_order ? "&sortorder=1" : "&sortorder=0" ) 
       . ($dom_select == '' ? '' : "&d=" . urlencode($dom_select)) 
       . ($org_select == '' ? '' : "&o=" . urlencode($org_select)) 
-      . ($per_select == '' ? '' : "&p=" . urlencode($per_select)) 
+      . ($per_select == '' ? "&p=all" : "&p=" . urlencode($per_select)) 
       . "#rpt". $row['serial'] . "'>". $row['reportid']. "</a></td>";
 		$reportlist[] =  "      <td class='center'>". number_format($row['rcount']+0,0). "</td>";
 		$reportlist[] =  "    </tr>";


### PR DESCRIPTION
Steps to reproduce:
- Open the page
- Select "[all]" as time period
- Click on a report that is not in the current month
- "Unknown report number!" is displayed

Workaround fix:
- add "&p=all" to the URL and it works

Explanations:
Only reports regarding the displayed page can be shown but since pull request https://github.com/techsneeze/dmarcts-report-viewer/pull/23 current month is the default.
So when there is no period selected, "p=all" must be enforced on links.
