### PR TITLE
Query both report start and end times to build the Month (selPeriod) …

### DIFF
--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -207,7 +207,7 @@ while($row = $query->fetch_assoc()) {
 
 // Get all periods
 // --------------------------------------------------------------------------
-$sql="SELECT DISTINCT DISTINCT year(mindate) as year, month(mindate) as month FROM `report` ORDER BY year desc, month desc";
+$sql="(SELECT year(mindate) as year, month(mindate) as month FROM `report`) UNION (SELECT year(maxdate) as year, month(maxdate) as month FROM `report`) ORDER BY year desc, month desc";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 


### PR DESCRIPTION
…select dropdown box in option bar

Updated the SQL query that builds the year-month entries for the Month (selPeriod) select dropdown box in the option bar from both the `mindate` (report start time) AND `maxdate` (report end time) columns in the `report` table. When a new month starts, the old SQL query would only use the 'mindate` (report start time) column to build the selPeriod select entries, meaning there could be report end times in the new month without a corresponding entry in the selPeriod dropdown box.