### PR TITLE
Dropdown defaults

### DIFF
--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -29,8 +29,34 @@
 // for your database authentication and location.
 //
 // Edit the configuration variables in dmarcts-report-viewer.js with your preferences.
-// 
-// 
+
+//####################################################################
+//### variables ######################################################
+//####################################################################
+
+$dmarc_result = array(
+	'DKIM_AND_SPF_PASS' => array(
+		'text' => 'DKIM and SPF Pass',
+		'color' => 'lime',
+		'status_num' => 1,
+	),
+	'DKIM_OR_SPF_FAIL' => array(
+		'text' => 'DKIM or SPF Fail',
+		'color' => 'orange',
+		'status_num' => 3,
+	),
+	'DKIM_AND_SPF_FAIL' => array(
+		'text' => 'DKIM and SPF Fail',
+		'color' => 'red',
+		'status_num' => 4,
+	),
+	'OTHER_CONDITION' => array(
+		'text' => 'Other condition',
+		'color' => 'yellow',
+		'status_num' => 2,
+	),
+);
+
 //####################################################################
 //### functions ######################################################
 //####################################################################
@@ -43,21 +69,22 @@ function main() {
 
 
 function get_status_color($row) {
+	global $dmarc_result;
 	$status = "";
 	$status_num = "";
-    if (($row['dkimresult'] == "fail") && ($row['spfresult'] == "fail")) {
-	    $status="red";
-		$status_num="4";
-    } elseif (($row['dkimresult'] == "fail") || ($row['spfresult'] == "fail")) {
-	    $status="orange";
-	    $status_num="3";
-    } elseif (($row['dkimresult'] == "pass") && ($row['spfresult'] == "pass")) {
-	    $status="lime";
-	    $status_num="1";
-    } else {
-	    $status="yellow";
-	    $status_num="2";
-    }
+	if (($row['dkimresult'] == "fail") && ($row['spfresult'] == "fail")) {
+		$status     = $dmarc_result['DKIM_AND_SPF_FAIL']['color'];
+		$status_num = $dmarc_result['DKIM_AND_SPF_FAIL']['status_num'];
+	} elseif (($row['dkimresult'] == "fail") || ($row['spfresult'] == "fail")) {
+		$status     = $dmarc_result['DKIM_OR_SPF_FAIL']['color'];
+		$status_num = $dmarc_result['DKIM_OR_SPF_FAIL']['status_num'];
+	} elseif (($row['dkimresult'] == "pass") && ($row['spfresult'] == "pass")) {
+		$status     = $dmarc_result['DKIM_AND_SPF_PASS']['color'];
+		$status_num = $dmarc_result['DKIM_AND_SPF_PASS']['status_num'];
+	} else {
+		$status     = $dmarc_result['OTHER_CONDITION']['color'];
+		$status_num = $dmarc_result['OTHER_CONDITION']['status_num'];
+	}
 #	$status .= "\"><span style='display:none;'>" . $status_content . "</span></span>";
 #	$status_num .= "\"><span style='display:none;'>" . $status_content . "</span></span>";
     return array($status, $status_num);

--- a/dmarcts-report-viewer-config.php.sample
+++ b/dmarcts-report-viewer-config.php.sample
@@ -15,4 +15,21 @@ $cssfile="default.css";
 $default_hostlookup = 1;  // Hostname resolution: 1=on 0=off (Turning off host lookup greatly speeds up the program in the case of mail servers that have ceased to exist)
 $default_sort = 1;  // Report listing Start Date: 1=ASCdending 0=DESCending (ASCending is default behaviour )
 
+
+// configure defaults (used on initial page load) for drop-downs
+
+// default for drop-down 'Domain(s)'
+// $default_domain = 'example.org';
+
+// default for drop-down ''Reporter(s)'
+// $default_reporter = 'google.com';
+
+// default for drop-down 'DMARC Result'
+// one of:
+// - DKIM_AND_SPF_PASS
+// - DKIM_OR_SPF_FAIL
+// - DKIM_AND_SPF_FAIL
+// - OTHER_CONDITION
+// $default_dmarc_result = 'DKIM_AND_SPF_FAIL';
+
 ?>

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -34,7 +34,7 @@
 //### functions ######################################################
 //####################################################################
 
-function html ($default_hostlookup = 1, $cssfile, $domains = array(), $orgs = array(), $periods = array() ) {
+function html ($default_hostlookup = 1, $default_domain = undef, $default_reporter = undef, $cssfile, $domains = array(), $orgs = array(), $periods = array() ) {
 
 	$html       = array();
 
@@ -100,10 +100,10 @@ function html ($default_hostlookup = 1, $cssfile, $domains = array(), $orgs = ar
 	if ( count( $domains ) >= 1 ) {
 		$html[] = "<div class='options'><span class='optionlabel'>Domain(s):</span>";
 		$html[] = "<select name=\"selDomain\" id=\"selDomain\" onchange=\"showReportlist('reportlistTbl')\">";
-		$html[] = "<option selected=\"selected\" value=\"all\">[all]</option>";
+		$html[] = "<option " . ( $default_domain ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 
 		foreach( $domains as $d) {
-			$html[] = "<option value=\"$d\">$d</option>";
+			$html[] = "<option " . ( $default_domain == $d ? "selected=\"selected\" " : "" ) . "value=\"$d\">$d</option>";
 		}
 
 		$html[] = "</select>";
@@ -116,10 +116,10 @@ function html ($default_hostlookup = 1, $cssfile, $domains = array(), $orgs = ar
 	if ( count( $orgs ) > 0 ) {
 		$html[] = "<div class='options'><span class='optionlabel'>Reporter(s):</span>";
 		$html[] = "<select name=\"selOrganisation\" id=\"selOrganisation\" onchange=\"showReportlist('reportlistTbl')\">";
-		$html[] = "<option selected=\"selected\" value=\"all\">[all]</option>";
+		$html[] = "<option " . ( $default_reporter ? "" : "selected=\"selected\" " ) . "selected=\"selected\" value=\"all\">[all]</option>";
 
 		foreach( $orgs as $o) {
-			$html[] = "<option value=\"$o\">" . ( strlen( $o ) > 25 ? substr( $o, 0, 22) . "..." : $o ) . "</option>";
+			$html[] = "<option " . ( $default_reporter == $o ? "selected=\"selected\" " : "" ) . "value=\"$o\">" . ( strlen( $o ) > 25 ? substr( $o, 0, 22) . "..." : $o ) . "</option>";
 		}
 
 		$html[] = "</select>";
@@ -219,6 +219,8 @@ while($row = $query->fetch_assoc()) {
 // --------------------------------------------------------------------------
 echo html( 
 	$default_hostlookup, 
+	$default_domain,
+	$default_reporter,
 	$cssfile, 
 	$domains, 
 	$orgs, 

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -34,7 +34,9 @@
 //### functions ######################################################
 //####################################################################
 
-function html ($default_hostlookup = 1, $default_domain = undef, $default_reporter = undef, $cssfile, $domains = array(), $orgs = array(), $periods = array() ) {
+function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_domain = undef, $default_reporter = undef, $cssfile, $domains = array(), $orgs = array(), $periods = array() ) {
+
+	global $dmarc_result;
 
 	$html       = array();
 
@@ -67,11 +69,14 @@ function html ($default_hostlookup = 1, $default_domain = undef, $default_report
 	// 	--------------------------------------------------------------------------
 		$html[] = "<div class='options'><span class='optionlabel'>DMARC Result:</span>";
 		$html[] = "<select name=\"selDMARC\" id=\"selDMARC\" onchange=\"showReportlist('reportlistTbl')\">";
-		$html[] = "<option selected=\"selected\" value=\"all\">[all]</option>";
-		$html[] = "<option value=\"1\">DKIM and SPF Pass</option>";
-		$html[] = "<option value=\"3\">DKIM or SPF Fail</option>";
-		$html[] = "<option value=\"4\">DKIM and SPF Fail</option>";
-		$html[] = "<option value=\"2\">Other condition</option>";
+		$html[] = "<option " . ( $default_dmarc_result ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
+		foreach($dmarc_result as $key => $value) {
+			$html[] = sprintf("<option %s value=\"%d\">%s</option>",
+					$default_dmarc_result == $key ? "selected=\"selected\"" : "",
+					$value['status_num'],
+					$value['text'],
+				);
+		}
 		$html[] = "</select>";
 		$html[] = "</div>";
 
@@ -219,6 +224,7 @@ while($row = $query->fetch_assoc()) {
 // --------------------------------------------------------------------------
 echo html( 
 	$default_hostlookup, 
+	$default_dmarc_result,
 	$default_domain,
 	$default_reporter,
 	$cssfile, 


### PR DESCRIPTION
Allow setting defaults for drop-downs.

In large organizations with a lot of domains, starting with 'all' in all drop-downs is sometimes slow, plus it's nice to see the most important stuff right away without fiddling with the interface.