### PR TITLE
Switch view to actual aligned results, not the raw DKIM/SPF results 

### DIFF
--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -72,13 +72,13 @@ function get_status_color($row) {
 	global $dmarc_result;
 	$status = "";
 	$status_num = "";
-	if (($row['dkimresult'] == "fail") && ($row['spfresult'] == "fail")) {
+	if (($row['dkim_align'] == "fail") && ($row['spf_align'] == "fail")) {
 		$status     = $dmarc_result['DKIM_AND_SPF_FAIL']['color'];
 		$status_num = $dmarc_result['DKIM_AND_SPF_FAIL']['status_num'];
-	} elseif (($row['dkimresult'] == "fail") || ($row['spfresult'] == "fail")) {
+	} elseif (($row['dkim_align'] == "fail") || ($row['spf_align'] == "fail")) {
 		$status     = $dmarc_result['DKIM_OR_SPF_FAIL']['color'];
 		$status_num = $dmarc_result['DKIM_OR_SPF_FAIL']['status_num'];
-	} elseif (($row['dkimresult'] == "pass") && ($row['spfresult'] == "pass")) {
+	} elseif (($row['dkim_align'] == "pass") && ($row['spf_align'] == "pass")) {
 		$status     = $dmarc_result['DKIM_AND_SPF_PASS']['color'];
 		$status_num = $dmarc_result['DKIM_AND_SPF_PASS']['status_num'];
 	} else {

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -35,6 +35,20 @@
 //####################################################################
 
 $dmarc_result = array(
+	'PASS' => array(
+		'text' => 'Pass',
+		'color' => 'lime',
+		'where_stmt' => "( rptrecord.dkim_align='pass' OR rptrecord.spf_align='pass' )",
+	),
+	'FAIL' => array(
+		'text' => 'Fail',
+		'color' => 'red',
+		'where_stmt' => "( NOT ( rptrecord.dkim_align='pass' OR rptrecord.spf_align='pass' ) )",
+	),
+);
+
+// currently unused, maybe introduce another drop-down to drill down on the details?
+$dkim_spf_result = array(
 	'DKIM_AND_SPF_PASS' => array(
 		'text' => 'DKIM and SPF Pass',
 		'color' => 'lime',
@@ -72,18 +86,10 @@ function get_status_color($row) {
 	global $dmarc_result;
 	$status = "";
 	$status_num = "";
-	if (($row['dkim_align'] == "fail") && ($row['spf_align'] == "fail")) {
-		$status     = $dmarc_result['DKIM_AND_SPF_FAIL']['color'];
-		$status_num = $dmarc_result['DKIM_AND_SPF_FAIL']['status_num'];
-	} elseif (($row['dkim_align'] == "fail") || ($row['spf_align'] == "fail")) {
-		$status     = $dmarc_result['DKIM_OR_SPF_FAIL']['color'];
-		$status_num = $dmarc_result['DKIM_OR_SPF_FAIL']['status_num'];
-	} elseif (($row['dkim_align'] == "pass") && ($row['spf_align'] == "pass")) {
-		$status     = $dmarc_result['DKIM_AND_SPF_PASS']['color'];
-		$status_num = $dmarc_result['DKIM_AND_SPF_PASS']['status_num'];
+	if (($row['dkim_align'] == "pass") || ($row['spf_align'] == "pass")) {
+		$status     = $dmarc_result['PASS']['color'];
 	} else {
-		$status     = $dmarc_result['OTHER_CONDITION']['color'];
-		$status_num = $dmarc_result['OTHER_CONDITION']['status_num'];
+		$status     = $dmarc_result['FAIL']['color'];
 	}
 #	$status .= "\"><span style='display:none;'>" . $status_content . "</span></span>";
 #	$status_num .= "\"><span style='display:none;'>" . $status_content . "</span></span>";

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -82,7 +82,7 @@ function main() {
 }
 
 
-function get_status_color($row) {
+function get_dmarc_color($row) {
 	global $dmarc_result;
 	$status = "";
 	$status_num = "";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -98,7 +98,7 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 
 	$query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 	while($row = $query->fetch_assoc()) {
-		$status = get_status_color($row);
+		$status = get_dmarc_color($row);
 
 		if ( $row['ip'] ) {
 			$ip = long2ip($row['ip']);
@@ -111,7 +111,7 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 		/* escape html characters after exploring binary values, which will be messed up */
 		$row = array_map('htmlspecialchars', $row);
 
-		$reportdata[] = "    <tr class='".get_status_color($row)[0]."'>";
+		$reportdata[] = "    <tr class='".get_dmarc_color($row)[0]."'>";
 		$reportdata[] = "      <td>". $ip. "</td>";
 		if ( $host_lookup ) {
 			$reportdata[] = "      <td>". gethostbyaddr($ip). "</td>";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -122,9 +122,9 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 		$reportdata[] = "      <td>". $row['disposition']. "</td>";
 		$reportdata[] = "      <td>". $row['reason']. "</td>";
 		$reportdata[] = "      <td>". $row['dkimdomain']. "</td>";
-		$reportdata[] = "      <td>". $row['dkimresult']. "</td>";
+		$reportdata[] = "      <td>". $row['dkim_align']. "</td>";
 		$reportdata[] = "      <td>". $row['spfdomain']. "</td>";
-		$reportdata[] = "      <td>". $row['spfresult']. "</td>";
+		$reportdata[] = "      <td>". $row['spf_align']. "</td>";
 		$reportdata[] = "    </tr>";
 
 		$reportsum += $row['rcount'];
@@ -230,20 +230,20 @@ if( $sortorder ) {
 }
 
 // DMARC
-// dkimresult spfresult
+// dkim_align spf_align
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
 	case 1: // DKIM and SPF Pass: Green
-		$dmarc_where = "(rptrecord.dkimresult='pass' AND rptrecord.spfresult='pass')";
+		$dmarc_where = "(rptrecord.dkim_align='pass' AND rptrecord.spf_align='pass')";
 		break;
 	case 3: // DKIM or SPF Fail: Orange
-		$dmarc_where = "(rptrecord.dkimresult='fail' OR rptrecord.spfresult='fail')";
+		$dmarc_where = "(rptrecord.dkim_align='fail' OR rptrecord.spf_align='fail')";
 		break;
 	case 4: // DKIM and SPF Fail: Red
-		$dmarc_where = "(rptrecord.dkimresult='fail' AND rptrecord.spfresult='fail')";
+		$dmarc_where = "(rptrecord.dkim_align='fail' AND rptrecord.spf_align='fail')";
 		break;
 	case 2: // Other condition: Yellow
-		$dmarc_where = "NOT ((rptrecord.dkimresult='pass' AND rptrecord.spfresult='pass') OR (rptrecord.dkimresult='fail' OR rptrecord.spfresult='fail') OR (rptrecord.dkimresult='fail' AND rptrecord.spfresult='fail'))"; // In other words, "NOT" all three other conditions
+		$dmarc_where = "NOT ((rptrecord.dkim_align='pass' AND rptrecord.spf_align='pass') OR (rptrecord.dkim_align='fail' OR rptrecord.spf_align='fail') OR (rptrecord.dkim_align='fail' AND rptrecord.spf_align='fail'))"; // In other words, "NOT" all three other conditions
 		break;
 	default:
 		break;
@@ -253,7 +253,7 @@ switch ($dmarc_select) {
 // for every single report.
 // --------------------------------------------------------------------------
 
-$sql = "SELECT report.* , sum(rptrecord.rcount) AS rcount, MIN(rptrecord.dkimresult) AS dkimresult, MIN(rptrecord.spfresult) AS spfresult FROM report LEFT JOIN (SELECT rcount, COALESCE(dkimresult, 'neutral') AS dkimresult, COALESCE(spfresult, 'neutral') AS spfresult, serial FROM rptrecord) AS rptrecord ON report.serial = rptrecord.serial WHERE report.serial = " . $mysqli->real_escape_string($reportid) . " GROUP BY serial ORDER BY mindate $sort, maxdate $sort , org";
+$sql = "SELECT report.* , sum(rptrecord.rcount) AS rcount, MIN(rptrecord.dkim_align) AS dkim_align, MIN(rptrecord.spf_align) AS spf_align FROM report LEFT JOIN (SELECT rcount, COALESCE(dkim_align, 'neutral') AS dkim_align, COALESCE(spf_align, 'neutral') AS spf_align, serial FROM rptrecord) AS rptrecord ON report.serial = rptrecord.serial WHERE report.serial = " . $mysqli->real_escape_string($reportid) . " GROUP BY serial ORDER BY mindate $sort, maxdate $sort , org";
 
 // Debug
 // echo "<br /><b>Data Report sql:</b> $sql<br />";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -233,17 +233,11 @@ if( $sortorder ) {
 // dkim_align spf_align
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
-	case 1: // DKIM and SPF Pass: Green
-		$dmarc_where = "(rptrecord.dkim_align='pass' AND rptrecord.spf_align='pass')";
+	case 'PASS': // DKIM or SPF Pass: Green
+		$dmarc_where = $dmarc_result[$dmarc_select]['where_stmt'];
 		break;
-	case 3: // DKIM or SPF Fail: Orange
-		$dmarc_where = "(rptrecord.dkim_align='fail' OR rptrecord.spf_align='fail')";
-		break;
-	case 4: // DKIM and SPF Fail: Red
-		$dmarc_where = "(rptrecord.dkim_align='fail' AND rptrecord.spf_align='fail')";
-		break;
-	case 2: // Other condition: Yellow
-		$dmarc_where = "NOT ((rptrecord.dkim_align='pass' AND rptrecord.spf_align='pass') OR (rptrecord.dkim_align='fail' OR rptrecord.spf_align='fail') OR (rptrecord.dkim_align='fail' AND rptrecord.spf_align='fail'))"; // In other words, "NOT" all three other conditions
+	case 'FAIL': // neither of DKIM or SPF Pass: Red
+		$dmarc_where = $dmarc_result[$dmarc_select]['where_stmt'];
 		break;
 	default:
 		break;

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -64,7 +64,7 @@ function tmpl_reportList($reports, $sort) {
 			$row = array_map('htmlspecialchars', $row);
 			$date_output_format = "Y-m-d G:i:s T";
 			$reportlist[] =  "    <tr class='linkable' onclick=\"showReport('" . $row['serial'] . "')\" id='report" . $row['serial'] . "'>";
-			$reportlist[] =  "      <td class='right'><span class=\"circle_".get_status_color($row)[0]."\"><span style='display:none;'>" . get_status_color($row)[1] . "</span></span></td>"; // Col 0
+			$reportlist[] =  "      <td class='right'><span class=\"circle_".get_dmarc_color($row)[0]."\"><span style='display:none;'>" . get_dmarc_color($row)[1] . "</span></span></td>"; // Col 0
 			$reportlist[] =  "      <td class='right'>". format_date($row['mindate'], $date_output_format). "</td>";   // Col 1
 			$reportlist[] =  "      <td class='right'>". format_date($row['maxdate'], $date_output_format). "</td>";   // Col 3
 			$reportlist[] =  "      <td class='center'>". $row['domain']. "</td>";                                     // Col 5

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -194,21 +194,16 @@ if( $sortorder ) {
 // dkim_align spf_align
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
-	case 1: // DKIM and SPF Pass: Green
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='pass' AND spf_align='pass')";
+	case 'PASS': // DKIM or SPF Pass: Green
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " " .  $dmarc_result[$dmarc_select]['where_stmt'];
 		break;
-	case 3: // DKIM or SPF Fail: Orange
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='fail' OR spf_align='fail')";
-		break;
-	case 4: // DKIM and SPF Fail: Red
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='fail' AND spf_align='fail')";
-		break;
-	case 2: // Other condition: Yellow
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " NOT ((dkim_align='pass' AND spf_align='pass') OR (dkim_align='fail' OR spf_align='fail') OR (dkim_align='fail' AND spf_align='fail'))"; // In other words, "NOT" all three other conditions
+	case 'FAIL': // neither of DKIM or SPF Pass: Red
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " " .  $dmarc_result[$dmarc_select]['where_stmt'];
 		break;
 	default: 
 		break;
 }
+
 
 // Domains
 // --------------------------------------------------------------------------

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -191,20 +191,20 @@ if( $sortorder ) {
 // Build SQL WHERE clause
 
 // DMARC
-// dkimresult spfresult
+// dkim_align spf_align
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
 	case 1: // DKIM and SPF Pass: Green
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='pass' AND spfresult='pass')";
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='pass' AND spf_align='pass')";
 		break;
 	case 3: // DKIM or SPF Fail: Orange
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='fail' OR spfresult='fail')";
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='fail' OR spf_align='fail')";
 		break;
 	case 4: // DKIM and SPF Fail: Red
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='fail' AND spfresult='fail')";
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkim_align='fail' AND spf_align='fail')";
 		break;
 	case 2: // Other condition: Yellow
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " NOT ((dkimresult='pass' AND spfresult='pass') OR (dkimresult='fail' OR spfresult='fail') OR (dkimresult='fail' AND spfresult='fail'))"; // In other words, "NOT" all three other conditions
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " NOT ((dkim_align='pass' AND spf_align='pass') OR (dkim_align='fail' OR spf_align='fail') OR (dkim_align='fail' AND spf_align='fail'))"; // In other words, "NOT" all three other conditions
 		break;
 	default: 
 		break;
@@ -235,7 +235,7 @@ if( $per_select <> '' ) {
 // --------------------------------------------------------------------------
 // $where = where_clause($dmarc_select, $dom_select, $org_select, $per_select);
 
-$sql = "SELECT report.* , sum(rptrecord.rcount) AS rcount, MIN(rptrecord.dkimresult) AS dkimresult, MIN(rptrecord.spfresult) AS spfresult FROM report LEFT JOIN (SELECT rcount, COALESCE(dkimresult, 'neutral') AS dkimresult, COALESCE(spfresult, 'neutral') AS spfresult, serial FROM rptrecord) AS rptrecord ON report.serial = rptrecord.serial $where GROUP BY serial ORDER BY mindate $sort, org";
+$sql = "SELECT report.* , sum(rptrecord.rcount) AS rcount, MIN(rptrecord.dkim_align) AS dkim_align, MIN(rptrecord.spf_align) AS spf_align FROM report LEFT JOIN (SELECT rcount, COALESCE(dkim_align, 'neutral') AS dkim_align, COALESCE(spf_align, 'neutral') AS spf_align, serial FROM rptrecord) AS rptrecord ON report.serial = rptrecord.serial $where GROUP BY serial ORDER BY mindate $sort, org";
 
 // Debug
 // echo "<br />sql where = $where<br />";

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -71,9 +71,9 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 		$html[] = "<select name=\"selDMARC\" id=\"selDMARC\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option " . ( $default_dmarc_result ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 		foreach($dmarc_result as $key => $value) {
-			$html[] = sprintf("<option %s value=\"%d\">%s</option>",
+			$html[] = sprintf("<option %s value=\"%s\">%s</option>",
 					$default_dmarc_result == $key ? "selected=\"selected\"" : "",
-					$value['status_num'],
+					$key,
 					$value['text'],
 				);
 		}


### PR DESCRIPTION
Previously, the viewer often showed things 'green' that actually were 'red', DMARC-wise, as it was not considering the results after alignment as provided in the reports' <policy_evaluated>, but the raw DKIM/SPF results (which might 'pass' but that doesn't help if they do not 'align' as well).