### PR TITLE
Add Alignment Results Display

### DIFF
--- a/default.css
+++ b/default.css
@@ -81,12 +81,27 @@ table.reportlist td {
 	padding:0px 10px;
 }
 
+table.reportlist td.circle_container {
+	padding-left: 0px;
+	padding-right: 0px;
+}
+
+table.reportlist td span.status_sort_key {
+	display: none;
+}
+
 table.reportlist th {
 	padding:3px;
 	position: -webkit-sticky; /* Safari */
 	position: sticky;
 	top: 0;
 	background-color: var(--header);
+	white-space: nowrap;
+}
+
+table.reportlist th.circle_container {
+	padding-left: 0px;
+	padding-right: 0px;
 }
 
 table.reportlist tr:hover {
@@ -207,39 +222,57 @@ table.reportdata tr.yellow {
 	text-align: right;
 }
 
-.circle_black:before {
-	content: ' \25CF';
-	font-size: 25px;
-	color: var(--text);
+.circle {
+    width: 7px;
+    height: 14px;
+	margin-top: 4px;
+    margin-bottom: 2px;
 }
 
-.circle_lime:before {
-	content: ' \25CF';
-	font-size: 25px;
-	color: var(--green);
+.circle_right {
+    border-bottom-right-radius: 500px;
+    border-top-right-radius: 500px;
+    border-left: 0;
+    display: inline-block;
 }
 
-.circle_red:before {
-	content: ' \25CF';
-	font-size: 25px;
-	color: var(--red);
+.circle_left {
+    border-bottom-left-radius: 500px;
+    border-top-left-radius: 500px;
+    border-right: 0;
+    display: inline-block;
 }
 
-.circle_yellow:before {
-	content: ' \25CF';
-	font-size: 25px;
-	color: var(--yellow);
+.circle_yellow {
+    width: 6px;
+    height: 12px;
+    background-color: yellow;
+	 border-top: 1px solid var(--selected);
+	 border-right: 1px solid var(--selected);
+	 border-bottom: 1px solid var(--selected);
+
 }
 
-.circle_orange:before {
-	content: ' \25CF';
-	font-size: 25px;
-	color: var(--orange);
+.circle_green {
+    background-color: lime;
+}
+
+.circle_orange {
+    background-color: orange;
+}
+
+.circle_red {
+    background-color: red;
+}
+
+.circle_black {
+    background-color: var(--text);
 }
 
 .asc_triangle:after {
 	content: ' \25B2';
 	font-size: 15px;
+	vertical-align: top;
 }
 
 .desc_triangle:after {

--- a/default.css
+++ b/default.css
@@ -172,7 +172,10 @@ table.reportdata tr.orange {
 	background-color: var(--orange);
 }
 
-table.reportdata tr.lime {
+table.reportdata tr.green {
+	background-color: var(--green);
+}
+
 	background-color: var(--green);
 }
 

--- a/default.css
+++ b/default.css
@@ -168,7 +168,15 @@ table.reportdata tr.red {
 	background-color: var(--red);
 }
 
+table.reportdata td.red {
+	background-color: var(--red);
+}
+
 table.reportdata tr.orange {
+	background-color: var(--orange);
+}
+
+table.reportdata td.orange {
 	background-color: var(--orange);
 }
 
@@ -176,10 +184,15 @@ table.reportdata tr.green {
 	background-color: var(--green);
 }
 
+table.reportdata td.green {
 	background-color: var(--green);
 }
 
 table.reportdata tr.yellow {
+	background-color: var(--yellow);
+}
+
+table.reportdata td.yellow {
 	background-color: var(--yellow);
 }
 

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -34,26 +34,32 @@
 //### variables ######################################################
 //####################################################################
 
+// The order in which the options appear here is the order they appear in the DMARC Results dropdown box
 $dmarc_result = array(
-	'DKIM_AND_SPF_PASS' => array(
-		'text' => 'DKIM and SPF Pass',
-		'color' => 'lime',
-		'status_num' => 1,
+
+	'DMARC_PASS' => array(
+		'text' => 'Pass',
+		'status_text' => 'All Passed.',
+		'color' => 'green',
+		'status_sort_key' => 3,
 	),
-	'DKIM_OR_SPF_FAIL' => array(
-		'text' => 'DKIM or SPF Fail',
-		'color' => 'orange',
-		'status_num' => 3,
-	),
-	'DKIM_AND_SPF_FAIL' => array(
-		'text' => 'DKIM and SPF Fail',
+	'DMARC_FAIL' => array(
+		'text' => 'Fail',
+		'status_text' => 'All Failed.',
 		'color' => 'red',
-		'status_num' => 4,
+		'status_sort_key' => 0,
 	),
-	'OTHER_CONDITION' => array(
-		'text' => 'Other condition',
+	'DMARC_PASS_AND_FAIL' => array(
+		'text' => 'Mixed',
+		'status_text' => 'At least one failed result.',
+		'color' => 'orange',
+		'status_sort_key' => 1,
+	),
+	'DMARC_OTHER_CONDITION' => array(
+		'text' => 'Other',
+		'status_text' => 'Other condition.',
 		'color' => 'yellow',
-		'status_num' => 2,
+		'status_sort_key' => 2,
 	),
 );
 

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -42,24 +42,28 @@ $dmarc_result = array(
 		'status_text' => 'All Passed',
 		'color' => 'green',
 		'status_sort_key' => 3,
+		'status_sql_where' => "dkim_align_min = 2 AND spf_align_min = 2 AND dkim_result_min = 2 AND spf_result_min = 2 AND dmarc_result_min = 2 AND dmarc_result_max = 2",
 	),
 	'DMARC_FAIL' => array(
 		'text' => 'Fail',
 		'status_text' => 'All Failed',
 		'color' => 'red',
 		'status_sort_key' => 0,
+		'status_sql_where' => "dkim_align_min = 0 AND spf_align_min = 0 AND dkim_result_min = 0 AND spf_result_min = 0 AND dmarc_result_min = 0 AND dmarc_result_max = 0",
 	),
 	'DMARC_PASS_AND_FAIL' => array(
 		'text' => 'Mixed',
 		'status_text' => 'At least one failed result',
 		'color' => 'orange',
 		'status_sort_key' => 1,
+		'status_sql_where' => "( dkim_align_min = 0 OR spf_align_min = 0 OR dkim_result_min = 0 OR spf_result_min = 0 OR dmarc_result_min = 0 OR dmarc_result_max = 0 )",
 	),
 	'DMARC_OTHER_CONDITION' => array(
 		'text' => 'Other',
 		'status_text' => 'Other condition',
 		'color' => 'yellow',
 		'status_sort_key' => 2,
+		'status_sql_where' => "( dkim_align_min = 1 OR spf_align_min = 1 OR dkim_result_min = 1 OR spf_result_min = 1 OR dmarc_result_min >= 3 OR dmarc_result_max >= 3 )",
 	),
 );
 
@@ -106,37 +110,38 @@ function get_report_status($row) {
 	global $dmarc_result;
 	$color = "";
 	$color_sort_key = "";
-	$result_text = "";
+	$status_text = "";
+	$status_sql_where = "";
 
-	$dmarc_status_min = min($row['dkim_align_min'],$row['spf_align_min'],$row['dkim_result_min'],$row['spf_result_min'],$row['dmarc_result_min']);
+	$report_status_min = min($row['dkim_align_min'],$row['spf_align_min'],$row['dkim_result_min'],$row['spf_result_min'],$row['dmarc_result_min']);
 
 	if ($row['dkim_align_min'] == 0 && $row['spf_align_min'] == 0 && $row['dkim_result_min'] == 0 && $row['spf_result_min'] == 0 && $row['dmarc_result_min'] == 0) {
 		$color = $dmarc_result['DMARC_FAIL']['color'];
 		$color_sort_key = $dmarc_result['DMARC_FAIL']['status_sort_key'];
-		$result_text = $dmarc_result['DMARC_FAIL']['status_text'];
+		$status_text = $dmarc_result['DMARC_FAIL']['status_text'];
 	} else {
-		switch ($dmarc_status_min) {
+		switch ($report_status_min) {
 			case 0:
 				$color = $dmarc_result['DMARC_PASS_AND_FAIL']['color'];
 				$color_sort_key = $dmarc_result['DMARC_PASS_AND_FAIL']['status_sort_key'];
-				$result_text = $dmarc_result['DMARC_PASS_AND_FAIL']['status_text'];
+				$status_text = $dmarc_result['DMARC_PASS_AND_FAIL']['status_text'];
 				break;
 			case 1:
 				$color = $dmarc_result['DMARC_OTHER_CONDITION']['color'];
 				$color_sort_key = $dmarc_result['DMARC_OTHER_CONDITION']['status_sort_key'];
-				$result_text = $dmarc_result['DMARC_OTHER_CONDITION']['status_text'];
+				$status_text = $dmarc_result['DMARC_OTHER_CONDITION']['status_text'];
 				break;
 			case 2:
 				$color = $dmarc_result['DMARC_PASS']['color'];
 				$color_sort_key = $dmarc_result['DMARC_PASS']['status_sort_key'];
-				$result_text = $dmarc_result['DMARC_PASS']['status_text'];
+				$status_text = $dmarc_result['DMARC_PASS']['status_text'];
 				break;
 			default:
 				break;
 		}
 	}
 
-	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'status_text' => $result_text);
+	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'status_text' => $status_text);
 }
 
 // This function sets variables for individual cells in the Report Data table
@@ -165,4 +170,3 @@ function format_date($date, $format) {
     $answer = date($format, strtotime($date));
     return $answer;
 };
-

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -139,30 +139,29 @@ function get_report_status($row) {
 	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'status_text' => $result_text);
 }
 
+// This function sets variables for individual cells in the Report Data table
+function get_status_color($result) {
 
-function get_status_color($row) {
 	global $dmarc_result;
-	$status = "";
-	$status_num = "";
-	if (($row['dkimresult'] == "fail") && ($row['spfresult'] == "fail")) {
-		$status     = $dmarc_result['DKIM_AND_SPF_FAIL']['color'];
-		$status_num = $dmarc_result['DKIM_AND_SPF_FAIL']['status_num'];
-	} elseif (($row['dkimresult'] == "fail") || ($row['spfresult'] == "fail")) {
-		$status     = $dmarc_result['DKIM_OR_SPF_FAIL']['color'];
-		$status_num = $dmarc_result['DKIM_OR_SPF_FAIL']['status_num'];
-	} elseif (($row['dkimresult'] == "pass") && ($row['spfresult'] == "pass")) {
-		$status     = $dmarc_result['DKIM_AND_SPF_PASS']['color'];
-		$status_num = $dmarc_result['DKIM_AND_SPF_PASS']['status_num'];
+	$color = "";
+	$color_sort_key = "";
+
+	if ($result == "fail") {
+		$color = $dmarc_result['DMARC_FAIL']['color'];
+#		$color_sort_key = $dmarc_result['STATUS_FAIL']['status_sort_key'];
+	} elseif ($result == "pass") {
+		$color = $dmarc_result['DMARC_PASS']['color'];
+#		$color_sort_key = $dmarc_result['STATUS_PASS']['status_sort_key'];
 	} else {
-		$status     = $dmarc_result['OTHER_CONDITION']['color'];
-		$status_num = $dmarc_result['OTHER_CONDITION']['status_num'];
+		$color = $dmarc_result['DMARC_OTHER_CONDITION']['color'];
+#		$color_sort_key = $dmarc_result['STATUS_OTHER_CONDITION']['status_sort_key'];
 	}
-#	$status .= "\"><span style='display:none;'>" . $status_content . "</span></span>";
-#	$status_num .= "\"><span style='display:none;'>" . $status_content . "</span></span>";
-    return array($status, $status_num);
+
+    return array('color' => $color, 'status_sort_key' => $color_sort_key);
 }
 
 function format_date($date, $format) {
+
     $answer = date($format, strtotime($date));
     return $answer;
 };

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -39,25 +39,25 @@ $dmarc_result = array(
 
 	'DMARC_PASS' => array(
 		'text' => 'Pass',
-		'status_text' => 'All Passed.',
+		'status_text' => 'All Passed',
 		'color' => 'green',
 		'status_sort_key' => 3,
 	),
 	'DMARC_FAIL' => array(
 		'text' => 'Fail',
-		'status_text' => 'All Failed.',
+		'status_text' => 'All Failed',
 		'color' => 'red',
 		'status_sort_key' => 0,
 	),
 	'DMARC_PASS_AND_FAIL' => array(
 		'text' => 'Mixed',
-		'status_text' => 'At least one failed result.',
+		'status_text' => 'At least one failed result',
 		'color' => 'orange',
 		'status_sort_key' => 1,
 	),
 	'DMARC_OTHER_CONDITION' => array(
 		'text' => 'Other',
-		'status_text' => 'Other condition.',
+		'status_text' => 'Other condition',
 		'color' => 'yellow',
 		'status_sort_key' => 2,
 	),

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -100,6 +100,43 @@ function get_dmarc_result($row) {
 	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'result' => $result_text);
 }
 
+// This function sets variables for the All Results portion (right half-circle) in the Report List table
+function get_report_status($row) {
+
+	global $dmarc_result;
+	$color = "";
+	$color_sort_key = "";
+	$result_text = "";
+
+	$dmarc_status_min = min($row['dkim_align_min'],$row['spf_align_min'],$row['dkim_result_min'],$row['spf_result_min'],$row['dmarc_result_min']);
+
+	if ($row['dkim_align_min'] == 0 && $row['spf_align_min'] == 0 && $row['dkim_result_min'] == 0 && $row['spf_result_min'] == 0 && $row['dmarc_result_min'] == 0) {
+		$color = $dmarc_result['DMARC_FAIL']['color'];
+		$color_sort_key = $dmarc_result['DMARC_FAIL']['status_sort_key'];
+		$result_text = $dmarc_result['DMARC_FAIL']['status_text'];
+	} else {
+		switch ($dmarc_status_min) {
+			case 0:
+				$color = $dmarc_result['DMARC_PASS_AND_FAIL']['color'];
+				$color_sort_key = $dmarc_result['DMARC_PASS_AND_FAIL']['status_sort_key'];
+				$result_text = $dmarc_result['DMARC_PASS_AND_FAIL']['status_text'];
+				break;
+			case 1:
+				$color = $dmarc_result['DMARC_OTHER_CONDITION']['color'];
+				$color_sort_key = $dmarc_result['DMARC_OTHER_CONDITION']['status_sort_key'];
+				$result_text = $dmarc_result['DMARC_OTHER_CONDITION']['status_text'];
+				break;
+			case 2:
+				$color = $dmarc_result['DMARC_PASS']['color'];
+				$color_sort_key = $dmarc_result['DMARC_PASS']['status_sort_key'];
+				$result_text = $dmarc_result['DMARC_PASS']['status_text'];
+				break;
+			default:
+				break;
+		}
+	}
+
+	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'status_text' => $result_text);
 }
 
 

--- a/dmarcts-report-viewer-common.php
+++ b/dmarcts-report-viewer-common.php
@@ -70,6 +70,35 @@ $dmarc_result = array(
 function main() {
 
 	include "dmarcts-report-viewer-config.php";
+}
+
+// This function sets variables for the DMARC Result portion (left half-circle) in the Report List
+function get_dmarc_result($row) {
+
+	global $dmarc_result;
+	$color = "";
+	$color_sort_key = "";
+	$result_text = "";
+
+	if (($row['dmarc_result_min'] == 0) && ($row['dmarc_result_max'] == 0)) {
+		$color     = $dmarc_result['DMARC_FAIL']['color'];
+		$color_sort_key = $dmarc_result['DMARC_FAIL']['status_sort_key'];
+		$result_text = $dmarc_result['DMARC_FAIL']['text'];
+	} elseif (($row['dmarc_result_min'] == 0) && ($row['dmarc_result_max'] == 1 || $row['dmarc_result_max'] == 2)) {
+		$color     = $dmarc_result['DMARC_PASS_AND_FAIL']['color'];
+		$color_sort_key = $dmarc_result['DMARC_PASS_AND_FAIL']['status_sort_key'];
+		$result_text = $dmarc_result['DMARC_PASS_AND_FAIL']['text'];
+	} elseif (($row['dmarc_result_min'] == 1 || $row['dmarc_result_min'] == 2) && ($row['dmarc_result_max'] == 1 || $row['dmarc_result_max'] == 2)) {
+		$color     = $dmarc_result['DMARC_PASS']['color'];
+		$color_sort_key = $dmarc_result['DMARC_PASS']['status_sort_key'];
+		$result_text = $dmarc_result['DMARC_PASS']['text'];
+	} else {
+		$color     = $dmarc_result['DMARC_OTHER_CONDITION']['color'];
+		$color_sort_key = $dmarc_result['DMARC_OTHER_CONDITION']['status_sort_key'];
+		$result_text = $dmarc_result['DMARC_OTHER_CONDITION']['text'];
+	}
+	return array('color' => $color, 'status_sort_key' => $color_sort_key, 'result' => $result_text);
+}
 
 }
 

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -123,7 +123,7 @@ SELECT
 	AS dmarc_result_max
 FROM
     rptrecord
-WHERE serial = " . $reportnumber;
+WHERE serial = " . $reportnumber . ( $dmarc_where ? " AND $dmarc_where" : "" ) . " ORDER BY ip ASC";
 
 // Debug
 // echo "<br><b>sql reportdata =</b> $sql<br>";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -55,7 +55,6 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 		$row = $reports[$reportnumber];
 		$row['raw_xml'] = formatXML($row['raw_xml']);
 		$row = array_map('htmlspecialchars', $row);
-//         $reportdata[] = "<a id='rpt".$reportnumber."'></a>";
 
 		$reportdata[] = "<div id='report_desc_container' class='center reportdesc_container'>";
 		$reportdata[] = "<div id='report_desc' class='center reportdesc'>Report from ".$row['org']." for ".$row['domain']."<br>(". format_date($row['mindate'], "r" ). " - ".format_date($row['maxdate'], "r" ).")<br> Policies: adkim=" . $row['policy_adkim'] . ", aspf=" . $row['policy_aspf'] .  ", p=" . $row['policy_p'] .  ", sp=" . $row['policy_sp'] .  ", pct=" . $row['policy_pct'] . "</div>";
@@ -87,7 +86,6 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 	$reportdata[] = "      <th title='" . $title_message . "'>SPF<br />Result</th>";
 	$reportdata[] = "    </tr>";
 	$reportdata[] = "  </thead>";
-
 	$reportdata[] = "  <tbody>";
 
 	global $mysqli;
@@ -252,7 +250,31 @@ switch ($dmarc_select) {
 // for every single report.
 // --------------------------------------------------------------------------
 
-$sql = "SELECT report.* , sum(rptrecord.rcount) AS rcount, MIN(rptrecord.dkimresult) AS dkimresult, MIN(rptrecord.spfresult) AS spfresult FROM report LEFT JOIN (SELECT rcount, COALESCE(dkimresult, 'neutral') AS dkimresult, COALESCE(spfresult, 'neutral') AS spfresult, serial FROM rptrecord) AS rptrecord ON report.serial = rptrecord.serial WHERE report.serial = " . $mysqli->real_escape_string($reportid) . " GROUP BY serial ORDER BY mindate $sort, maxdate $sort , org";
+$sql = "
+SELECT
+	report.*,
+	sum(rptrecord.rcount) AS rcount,
+	MIN(rptrecord.dkimresult) AS dkimresult,
+	MIN(rptrecord.spfresult) AS spfresult
+FROM
+	report
+LEFT JOIN
+	(
+	SELECT
+		rcount,
+		COALESCE(dkimresult, 'neutral') AS dkimresult,
+		COALESCE(spfresult, 'neutral') AS spfresult,
+		serial
+	FROM
+		rptrecord
+	)
+	AS rptrecord
+ON
+	report.serial = rptrecord.serial
+WHERE report.serial = " . $mysqli->real_escape_string($reportid) . "
+GROUP BY serial
+ORDER BY mindate $sort, maxdate $sort , org";
+
 
 // Debug
 // echo "<br /><b>Data Report sql:</b> $sql<br />";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -270,16 +270,16 @@ if( $sortorder ) {
 // dkimresult spfresult
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
-	case 1: // DKIM and SPF Pass: Green
+	case "DMARC_PASS": // DKIM and SPF Pass: Green
 		$dmarc_where = "(rptrecord.dkimresult='pass' AND rptrecord.spfresult='pass')";
 		break;
-	case 3: // DKIM or SPF Fail: Orange
+	case "DMARC_PASS_AND_FAIL": // DKIM or SPF Fail: Orange
 		$dmarc_where = "(rptrecord.dkimresult='fail' OR rptrecord.spfresult='fail')";
 		break;
-	case 4: // DKIM and SPF Fail: Red
+	case "DMARC_FAIL": // DKIM and SPF Fail: Red
 		$dmarc_where = "(rptrecord.dkimresult='fail' AND rptrecord.spfresult='fail')";
 		break;
-	case 2: // Other condition: Yellow
+	case "DMARC_OTHER_CONDITION": // Other condition: Yellow
 		$dmarc_where = "NOT ((rptrecord.dkimresult='pass' AND rptrecord.spfresult='pass') OR (rptrecord.dkimresult='fail' OR rptrecord.spfresult='fail') OR (rptrecord.dkimresult='fail' AND rptrecord.spfresult='fail'))"; // In other words, "NOT" all three other conditions
 		break;
 	default:

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -292,29 +292,12 @@ switch ($dmarc_select) {
 
 $sql = "
 SELECT
-	report.*,
-	sum(rptrecord.rcount) AS rcount,
-	MIN(rptrecord.dkimresult) AS dkimresult,
-	MIN(rptrecord.spfresult) AS spfresult
+	*
 FROM
 	report
-LEFT JOIN
-	(
-	SELECT
-		rcount,
-		COALESCE(dkimresult, 'neutral') AS dkimresult,
-		COALESCE(spfresult, 'neutral') AS spfresult,
-		serial
-	FROM
-		rptrecord
-	)
-	AS rptrecord
-ON
-	report.serial = rptrecord.serial
-WHERE report.serial = " . $mysqli->real_escape_string($reportid) . "
-GROUP BY serial
-ORDER BY mindate $sort, maxdate $sort , org";
-
+WHERE
+	serial = " . $mysqli->real_escape_string($reportid)
+;
 
 // Debug
 // echo "<br /><b>Data Report sql:</b> $sql<br />";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -96,34 +96,38 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 
 $sql = "
 SELECT
-    *,
-    (CASE
+  *,
+  (CASE
 		WHEN dkim_align = 'fail' THEN 0
 		WHEN dkim_align = 'pass' THEN 1
 		ELSE 3
-    END)
-    +
-    (CASE
+  END)
+  +
+  (CASE
 		WHEN spf_align = 'fail' THEN 0
 		WHEN spf_align = 'pass' THEN 1
 		ELSE 3
-	END)
+		END)
 	AS dmarc_result_min,
 	(CASE
 		WHEN dkim_align = 'fail' THEN 0
 		WHEN dkim_align = 'pass' THEN 1
 		ELSE 3
-    END)
-    +
-    (CASE
+  END)
+  +
+  (CASE
 		WHEN spf_align = 'fail' THEN 0
 		WHEN spf_align = 'pass' THEN 1
 		ELSE 3
 	END)
 	AS dmarc_result_max
 FROM
-    rptrecord
-WHERE serial = " . $reportnumber . ( $dmarc_where ? " AND $dmarc_where" : "" ) . " ORDER BY ip ASC";
+  rptrecord
+WHERE
+	serial = " . $reportnumber . ( $dmarc_where ? " AND $dmarc_where" : "" ) . "
+ORDER BY
+	ip ASC
+";
 
 // Debug
 // echo "<br><b>sql reportdata =</b> $sql<br>";

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -89,7 +89,38 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 	$reportdata[] = "  <tbody>";
 
 	global $mysqli;
-	$sql = "SELECT * FROM rptrecord where serial = $reportnumber" . ( $dmarc_where ? " AND $dmarc_where" : "" ) . " ORDER BY ip ASC";
+
+$sql = "
+SELECT
+    *,
+    (CASE
+		WHEN dkim_align = 'fail' THEN 0
+		WHEN dkim_align = 'pass' THEN 1
+		ELSE 3
+    END)
+    +
+    (CASE
+		WHEN spf_align = 'fail' THEN 0
+		WHEN spf_align = 'pass' THEN 1
+		ELSE 3
+	END)
+	AS dmarc_result_min,
+	(CASE
+		WHEN dkim_align = 'fail' THEN 0
+		WHEN dkim_align = 'pass' THEN 1
+		ELSE 3
+    END)
+    +
+    (CASE
+		WHEN spf_align = 'fail' THEN 0
+		WHEN spf_align = 'pass' THEN 1
+		ELSE 3
+	END)
+	AS dmarc_result_max
+FROM
+    rptrecord
+WHERE serial = " . $reportnumber;
+
 // Debug
 // echo "<br><b>sql reportdata =</b> $sql<br>";
 

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -29,8 +29,8 @@
 // for your database authentication and location.
 //
 // Edit the configuration variables in dmarcts-report-viewer.js with your preferences.
-// 
-// 
+//
+//
 //####################################################################
 //### functions ######################################################
 //####################################################################
@@ -103,7 +103,6 @@ $org_select= '';
 $per_select= '';
 $dmarc_select= '';
 $where = '';
-
 
 // Parameters of GET
 // --------------------------------------------------------------------------

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -201,16 +201,16 @@ if( $sortorder ) {
 switch ($dmarc_select) {
 	case "all": // Everything
 		break;
-	case 0: // DMARC Fail
+	case "DMARC_FAIL": // DMARC Fail
 		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min = 0 AND dmarc_result_max = 0";
 		break;
-	case 1: // DMARC Pass and Fail
+	case "DMARC_PASS_AND_FAIL": // DMARC Pass and Fail
 		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min = 0 AND (dmarc_result_max = 1 OR dmarc_result_max = 2)";
 		break;
-	case 2: // Other condition: Yellow
+	case "DMARC_OTHER_CONDITION": // Other condition: Yellow
 		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min >= 3 AND dmarc_result_max >= 3";
 		break;
-	case 3: // DMARC Pass
+	case "DMARC_PASS": // DMARC Pass
 		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dmarc_result_min = 1 OR dmarc_result_min = 2) AND (dmarc_result_max <= 2)";
 		break;
 	default:

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -165,10 +165,6 @@ if(isset($_GET['dmarc'])){
 	$dmarc_select= '';
 }
 
-if( $dmarc_select == "all" ) {
-	$dmarc_select= '';
-}
-
 // Debug
 // echo "<br />D=$dom_select <br /> O=$org_select <br />";
 // echo "<br />DMARC=$dmarc_select<br />";
@@ -200,23 +196,24 @@ if( $sortorder ) {
 
 // Build SQL WHERE clause
 
-// DMARC
-// dkimresult spfresult
+// DMARC Result
 // --------------------------------------------------------------------------
 switch ($dmarc_select) {
-	case 1: // DKIM and SPF Pass: Green
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='pass' AND spfresult='pass')";
+	case "all": // Everything
 		break;
-	case 3: // DKIM or SPF Fail: Orange
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='fail' OR spfresult='fail')";
+	case 0: // DMARC Fail
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min = 0 AND dmarc_result_max = 0";
 		break;
-	case 4: // DKIM and SPF Fail: Red
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dkimresult='fail' AND spfresult='fail')";
+	case 1: // DMARC Pass and Fail
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min = 0 AND (dmarc_result_max = 1 OR dmarc_result_max = 2)";
 		break;
 	case 2: // Other condition: Yellow
-		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " NOT ((dkimresult='pass' AND spfresult='pass') OR (dkimresult='fail' OR spfresult='fail') OR (dkimresult='fail' AND spfresult='fail'))"; // In other words, "NOT" all three other conditions
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " dmarc_result_min >= 3 AND dmarc_result_max >= 3";
 		break;
-	default: 
+	case 3: // DMARC Pass
+		$where .= ( $where <> '' ? " AND" : " WHERE" ) . " (dmarc_result_min = 1 OR dmarc_result_min = 2) AND (dmarc_result_max <= 2)";
+		break;
+	default:
 		break;
 }
 

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -243,20 +243,20 @@ if( $per_select <> '' ) {
 
 $sql = "
 SELECT
-    report.*,
-    rcount,
-    dkim_align_min,
-    spf_align_min,
-    dkim_result_min,
-    spf_result_min,
-    dmarc_result_min,
-    dmarc_result_max
+  report.*,
+  rcount,
+  dkim_align_min,
+  spf_align_min,
+  dkim_result_min,
+  spf_result_min,
+  dmarc_result_min,
+  dmarc_result_max
 FROM
-    report
+  report
 	LEFT JOIN
 		(
 			SELECT
-				SUM(rcount) as rcount,
+				SUM(rcount) AS rcount,
 				serial,
 				dkim_align,
 				spf_align,
@@ -324,16 +324,19 @@ FROM
 				AS dmarc_result_max
 			FROM
 				rptrecord
-			GROUP BY serial
+			GROUP BY
+				serial
 		)
-	AS rptrecord
-ON
-	report.serial = rptrecord.serial
+		AS rptrecord
+	ON
+		report.serial = rptrecord.serial
 $where
-GROUP BY serial
+GROUP BY
+	serial
 ORDER BY
     mindate $sort,
-    org";
+    org
+";
 
 // Debug
 // echo "<br />sql where = $where<br />";

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -108,6 +108,7 @@ $dom_select= '';
 $org_select= '';
 $per_select= '';
 $dmarc_select= '';
+$report_status = '';
 $where = '';
 
 // Parameters of GET
@@ -165,6 +166,12 @@ if(isset($_GET['dmarc'])){
 	$dmarc_select= '';
 }
 
+if(isset($_GET['rptstat'])){
+	$report_status = $_GET['rptstat'];
+}else{
+	$report_status = '';
+}
+
 // Debug
 // echo "<br />D=$dom_select <br /> O=$org_select <br />";
 // echo "<br />DMARC=$dmarc_select<br />";
@@ -215,6 +222,12 @@ switch ($dmarc_select) {
 		break;
 	default:
 		break;
+}
+
+// Report Status
+// --------------------------------------------------------------------------
+if ( $report_status != "all" ) {
+	$where .= ( $where <> '' ? " AND" : " WHERE" ) . " " . $dmarc_result[$report_status]['status_sql_where'];
 }
 
 // Domains

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -42,7 +42,8 @@ function tmpl_reportList($reports, $sort) {
 	if (sizeof($reports) == 0) {
 		$reportlist[] = "<div class='center'><b>No Reports Match this filter</b><br />Click the <i>Reset</i> button or choose a different value for <i>DMARC Result</i>, <i>Month</i>, <i>Domain(s)</i> or <i>Reporter(s)</i>.</div>";
 	} else {
-		$title_message = "Click to toggle sort direction by this column";
+		$title_message_th = "Click to toggle sort direction by this column.";
+		$title_message_tr = "Click to view detailed report data.";
 	// echo $sort;
 		//	Resizer handles
 		//	--------------------------------------------------------------------------
@@ -51,13 +52,15 @@ function tmpl_reportList($reports, $sort) {
 		$reportlist[] = "<table id='reportlistTbl' class='reportlist'>";
 		$reportlist[] = "  <thead>";
 		$reportlist[] = "    <tr>";
-		$reportlist[] = "      <th title='" . $title_message . "'><span class=\"circle_black\"><span style='display:none;'>1</span></span></th>";
-		$reportlist[] = "      <th class=\"" . strtolower($sort) . "_triangle\" title='" . $title_message . "'>Start Date</th>";
-		$reportlist[] = "      <th title='" . $title_message . "'>End Date</th>";
-		$reportlist[] = "      <th title='" . $title_message . "'>Domain</th>";
-		$reportlist[] = "      <th title='" . $title_message . "'>Reporting Organization</th>";
-		$reportlist[] = "      <th title='" . $title_message . " (currently doesn&#39;t really sort well)'>Report ID</th>";
-		$reportlist[] = "      <th title='" . $title_message . "'>Messages</th>";
+		$reportlist[] = "      <th class='circle_container' style='padding-left: 5px' title='DMARC Result. " . $title_message_th . "'><div class='circle circle_left circle_black'></div><span style='display:none;'>1</span></span></th>";
+		$reportlist[] = "      <th class='circle_container'></th>";
+		$reportlist[] = "      <th class='circle_container' title='SPF/DKIM/DMARC Results. " . $title_message_th . "'><div class='circle circle_right circle_black'></div><span style='display:none;'>1</span></span></th>";
+		$reportlist[] = "      <th class=\"" . strtolower($sort) . "_triangle\" title='" . $title_message_th . "'>Start Date</th>";
+		$reportlist[] = "      <th title='" . $title_message_th . "'>End Date</th>";
+		$reportlist[] = "      <th title='" . $title_message_th . "'>Domain</th>";
+		$reportlist[] = "      <th title='" . $title_message_th . "'>Reporting Organization</th>";
+		$reportlist[] = "      <th title='" . $title_message_th . " (currently doesn&#39;t really sort well)'>Report ID</th>";
+		$reportlist[] = "      <th title='" . $title_message_th . "'>Messages</th>";
 		$reportlist[] = "    </tr>";
 		$reportlist[] = "  </thead>";
 
@@ -67,20 +70,23 @@ function tmpl_reportList($reports, $sort) {
 		foreach ($reports as $row) {
 			$row = array_map('htmlspecialchars', $row);
 			$date_output_format = "Y-m-d G:i:s T";
-			$reportlist[] =  "    <tr class='linkable' onclick=\"showReport('" . $row['serial'] . "')\" id='report" . $row['serial'] . "'>";
-			$reportlist[] =  "      <td class='right'><span class=\"circle_".get_status_color($row)[0]."\"><span style='display:none;'>" . get_status_color($row)[1] . "</span></span></td>"; // Col 0
+			$reportlist[] =  "    <tr class='linkable' onclick=\"showReport('" . $row['serial'] . "')\" id='report" . $row['serial'] . "' title='" . $title_message_tr . "'>";
+
+			$reportlist[] =  "      <td class='circle_container'><span class='status_sort_key'>" . get_dmarc_result($row)['status_sort_key'] . "</span></td>"; // Col 0
+			$reportlist[] =  "      <td class='circle_container'><div style='white-space: nowrap;' title='DMARC: " . get_dmarc_result($row)['result'] . "\nSPF/DKIM/DMARC: " . get_report_status($row)['status_text'] . "\n" . $title_message_tr . "'><div class='circle circle_left circle_" . get_dmarc_result($row)['color'] . "'></div><div class='circle circle_right circle_" . get_report_status($row)['color'] . "'></div></div></td>"; // Col 0
+			$reportlist[] =  "      <td class='circle_container'><span class='status_sort_key'>" . get_report_status($row)['status_sort_key'] . "</span></span></td>"; // Col 0
 			$reportlist[] =  "      <td class='right'>". format_date($row['mindate'], $date_output_format). "</td>";   // Col 1
 			$reportlist[] =  "      <td class='right'>". format_date($row['maxdate'], $date_output_format). "</td>";   // Col 3
 			$reportlist[] =  "      <td class='center'>". $row['domain']. "</td>";                                     // Col 5
 			$reportlist[] =  "      <td class='center'>". $row['org']. "</td>";                                        // Col 6
 			$reportlist[] =  "      <td class='center'>". $row['reportid'] . "</td>";
-			$reportlist[] =  "      <td class='center'>". number_format($row['rcount']+0,0). "</td>";                  // Col 9
+			$reportlist[] =  "      <td class='right'>". number_format($row['rcount']+0,0). "</td>";                  // Col 9
 			$reportlist[] =  "    </tr>";
 			$reportsum += $row['rcount'];
 		}
 
 		$reportlist[] =  "  </tbody>";
-		$reportlist[] = "<tr class='sum'><td></td><td></td><td></td><td></td><td></td><td class='right'>Sum:</td><td class='center'>".number_format($reportsum,0)."</td></tr>";
+		$reportlist[] = "<tr class='sum'><td class='circle_container'></td><td class='circle_container'></td><td class='circle_container'></td><td></td><td></td><td></td><td></td><td class='right'>Sum:</td><td class='right'>".number_format($reportsum,0)."</td></tr>";
 		$reportlist[] =  "</table>";
 
 		$reportlist[] = "<!-- End of report list -->";

--- a/dmarcts-report-viewer.js
+++ b/dmarcts-report-viewer.js
@@ -52,7 +52,7 @@ function reset_report_list() {
 
 	filter = document.getElementsByTagName("select");
 	for (i = 0; i < filter.length; i++) {
-		filter[i].value = "all";
+		filter[i].selectedIndex = 0;
 	}
 	refresh_report_list();
 }

--- a/dmarcts-report-viewer.js
+++ b/dmarcts-report-viewer.js
@@ -98,11 +98,13 @@ function showReportlist(str) { // str is the name of the <div> to be filled
 	var org = document.getElementById('selOrganisation').options[document.getElementById('selOrganisation').selectedIndex].value;
 	var period = document.getElementById('selPeriod').options[document.getElementById('selPeriod').selectedIndex].value;
 	var dmarc = document.getElementById('selDMARC').options[document.getElementById('selDMARC').selectedIndex].value;
+	var report_status = document.getElementById('selReportStatus').options[document.getElementById('selReportStatus').selectedIndex].value;
 
 	GETstring += "d=" + domain;
 	GETstring += "&o=" + org;
 	GETstring += "&p=" + period;
 	GETstring += "&dmarc=" + dmarc;
+	GETstring += "&rptstat=" + report_status;
 
 	xhttp = new XMLHttpRequest();
 	xhttp.onreadystatechange =

--- a/dmarcts-report-viewer.js
+++ b/dmarcts-report-viewer.js
@@ -122,7 +122,7 @@ function showReportlist(str) { // str is the name of the <div> to be filled
 							document.getElementById('resizer_vertical').style.display = 'none';
 				}
 			}
-		}
+		};
 
 	xhttp.open("GET", "dmarcts-report-viewer-report-list.php" + GETstring, true);
 	xhttp.send();
@@ -273,7 +273,7 @@ function showReport(str) {
 					showXML("open_xml");
 				}
 			}
-		}
+		};
 
 	xhttp.open("GET", "dmarcts-report-viewer-report-data.php?" + GETstring, true);
 	xhttp.send();

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -74,7 +74,7 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 		foreach($dmarc_result as $key => $value) {
 			$html[] = sprintf("<option style='color: " . $value['color'] . "' %s value=\"%d\">%s</option>",
 					$default_dmarc_result == $key ? "selected=\"selected\"" : "",
-					$value['status_sort_key'],
+					$key,
 					$value['text'],
 				);
 		}

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -194,12 +194,14 @@ if ($mysqli->connect_errno) {
 
 // Get all domains reported
 // --------------------------------------------------------------------------
-$sql="
-SELECT
-	DISTINCT domain
+$sql = "
+SELECT DISTINCT
+	domain
 FROM
 	report
-ORDER BY domain";
+ORDER BY
+	domain
+";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 
@@ -209,12 +211,14 @@ while($row = $query->fetch_assoc()) {
 
 // Get all organisations
 // --------------------------------------------------------------------------
-$sql="
-SELECT
-	DISTINCT org
+$sql = "
+SELECT DISTINCT
+	org
 FROM
 	report
-ORDER BY org";
+ORDER BY
+	org
+";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 
@@ -224,23 +228,26 @@ while($row = $query->fetch_assoc()) {
 
 // Get all periods
 // --------------------------------------------------------------------------
-$sql="
+$sql = "
 (
 	SELECT
-		year(mindate) as year,
-		month(mindate) as month
+		YEAR(mindate) AS year,
+		MONTH(mindate) AS month
 	FROM
 		report
 )
 UNION
 (
 	SELECT
-		year(maxdate) as year,
-		month(maxdate) as month
+		YEAR(maxdate) AS year,
+		MONTH(maxdate) AS month
 	FROM
 		report
 )
-ORDER BY year desc, month desc";
+ORDER BY
+	year DESC,
+	month DESC
+";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -63,16 +63,17 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 
 	//	Host lookup option
 	//	--------------------------------------------------------------------------
-	$html[] = "<div class='options'><span class='optionlabel'>Hostname(s):</span> <input type=\"radio\" name=\"selHostLookup\" value=\"1\" onclick=\"showReport(current_report)\"" . ($default_hostlookup ? " checked=\"checked\"" : "" ) . "> on<input type=\"radio\" name=\"selHostLookup\" value=\"0\" onclick=\"showReport(current_report)\"" . ($default_hostlookup ? "" : " checked=\"checked\"" ) . "> off</div>";
+	$html[] = "<div class='options'><span class='optionlabel'>Hostname(s):</span><br>";
+		$html[] = "<input type=\"radio\" name=\"selHostLookup\" value=\"1\" onclick=\"showReport(current_report)\"" . ($default_hostlookup ? " checked=\"checked\"" : "" ) . "> on<input type=\"radio\" name=\"selHostLookup\" value=\"0\" onclick=\"showReport(current_report)\"" . ($default_hostlookup ? "" : " checked=\"checked\"" ) . "> off</div>";
 
 
 	// 	DMARC select
 	// 	--------------------------------------------------------------------------
-		$html[] = "<div class='options'><span class='optionlabel'>DMARC Result:</span>";
+		$html[] = "<div class='options'><span class='optionlabel'>DMARC Result:</span><br>";
 		$html[] = "<select name=\"selDMARC\" id=\"selDMARC\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option " . ( $default_dmarc_result ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 		foreach($dmarc_result as $key => $value) {
-			$html[] = sprintf("<option style='color: " . $value['color'] . "' %s value=\"%d\">%s</option>",
+			$html[] = sprintf("<option style='color: " . $value['color'] . "' %s value=\"%s\">%s</option>",
 					$default_dmarc_result == $key ? "selected=\"selected\"" : "",
 					$key,
 					$value['text'],
@@ -101,7 +102,7 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 	// 	Period select
 	// 	--------------------------------------------------------------------------
 	if ( count( $periods ) > 0 ) {
-		$html[] = "<div class='options'><span class='optionlabel'>Month:</span>";
+		$html[] = "<div class='options'><span class='optionlabel'>Month:</span><br>";
 		$html[] = "<select name=\"selPeriod\" id=\"selPeriod\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option value=\"all\">[all]</option>";
 
@@ -121,7 +122,7 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 	//	Domains select
 	//	--------------------------------------------------------------------------
 	if ( count( $domains ) >= 1 ) {
-		$html[] = "<div class='options'><span class='optionlabel'>Domain(s):</span>";
+		$html[] = "<div class='options'><span class='optionlabel'>Domain(s):</span><br>";
 		$html[] = "<select name=\"selDomain\" id=\"selDomain\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option " . ( $default_domain ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 
@@ -137,7 +138,7 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 	//	Organizations select
 	//	--------------------------------------------------------------------------
 	if ( count( $orgs ) > 0 ) {
-		$html[] = "<div class='options'><span class='optionlabel'>Reporter(s):</span>";
+		$html[] = "<div class='options'><span class='optionlabel'>Reporter(s):</span><br>";
 		$html[] = "<select name=\"selOrganisation\" id=\"selOrganisation\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option " . ( $default_reporter ? "" : "selected=\"selected\" " ) . "selected=\"selected\" value=\"all\">[all]</option>";
 

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -72,10 +72,10 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 		$html[] = "<select name=\"selDMARC\" id=\"selDMARC\" onchange=\"showReportlist('reportlistTbl')\">";
 		$html[] = "<option " . ( $default_dmarc_result ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 		foreach($dmarc_result as $key => $value) {
-			$html[] = sprintf("<option %s value=\"%d\">%s</option>",
+			$html[] = sprintf("<option style='color: " . $value['color'] . "' %s value=\"%d\">%s</option>",
 					$default_dmarc_result == $key ? "selected=\"selected\"" : "",
-					$value['status_num'],
-					$value['text']
+					$value['status_sort_key'],
+					$value['text'],
 				);
 		}
 		$html[] = "</select>";

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -194,7 +194,12 @@ if ($mysqli->connect_errno) {
 
 // Get all domains reported
 // --------------------------------------------------------------------------
-$sql="SELECT DISTINCT domain FROM `report` ORDER BY domain";
+$sql="
+SELECT
+	DISTINCT domain
+FROM
+	report
+ORDER BY domain";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 
@@ -204,7 +209,12 @@ while($row = $query->fetch_assoc()) {
 
 // Get all organisations
 // --------------------------------------------------------------------------
-$sql="SELECT DISTINCT org FROM `report` ORDER BY org";
+$sql="
+SELECT
+	DISTINCT org
+FROM
+	report
+ORDER BY org";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 
@@ -214,7 +224,23 @@ while($row = $query->fetch_assoc()) {
 
 // Get all periods
 // --------------------------------------------------------------------------
-$sql="(SELECT year(mindate) as year, month(mindate) as month FROM `report`) UNION (SELECT year(maxdate) as year, month(maxdate) as month FROM `report`) ORDER BY year desc, month desc";
+$sql="
+(
+	SELECT
+		year(mindate) as year,
+		month(mindate) as month
+	FROM
+		report
+)
+UNION
+(
+	SELECT
+		year(maxdate) as year,
+		month(maxdate) as month
+	FROM
+		report
+)
+ORDER BY year desc, month desc";
 
 $query = $mysqli->query($sql) or die("Query failed: ".$mysqli->error." (Error #" .$mysqli->errno.")");
 

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -82,6 +82,22 @@ function html ($default_hostlookup = 1, $default_dmarc_result = undef, $default_
 		$html[] = "</div>";
 
 
+		// 	Report Status select
+		// 	--------------------------------------------------------------------------
+			$html[] = "<div class='options'><span class='optionlabel'>Report Status:</span><br>";
+			$html[] = "<select name=\"ReportStatus\" id=\"selReportStatus\" onchange=\"showReportlist('reportlistTbl')\">";
+			$html[] = "<option " . ( $default_report_status ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
+			foreach($dmarc_result as $key => $value) {
+				$html[] = sprintf("<option style='color: " . $value['color'] . "' %s value=\"%s\">%s</option>",
+						$default_report_status == $key ? "selected=\"selected\"" : "",
+						$key,
+						$value['status_text'],
+					);
+			}
+			$html[] = "</select>";
+			$html[] = "</div>";
+
+
 	// 	Period select
 	// 	--------------------------------------------------------------------------
 	if ( count( $periods ) > 0 ) {


### PR DESCRIPTION
This is a big update.

Basically, this changes the focus of dmarcts from SPF/DKIM Authentication results to the overall DMARC result.

The biggest outward appearance update is the addition of the colour-coded circles on the Report List and the extra columns on the Report Data table to display SPF/DKIM alignment and overall DMARC results.

The color-coded circles are split into a left half, which displays the overall DMARC result, and the right half, which displays the status of the Report Data. Each half is independently color-coded, so you can end up with the two halves being different colours depending on the results. The Report List can be sorted by the overall DMARC result and the Report Data status (i.e. each half of the circle).

Each individual result in the Report Data table is now independently colour-coded as well.

Behind the scenes are updates to some SQL statements, the addition of three new functions to display the results and the additions of the above-mentioned columns in the Report Table.

A big thank-you to @wolfgangkarall who inspired this update with pull request #54; some of that code survives in this update.