### PR TITLE
Issue Fixes

### DIFF
--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -228,7 +228,7 @@ switch ($dmarc_select) {
 // Report Status
 // --------------------------------------------------------------------------
 if ( $report_status != "all" && $report_status != "" ) {
-	$where .= ( $where <> '' ? " AND" : " WHERE" ) . " " . $dmarc_result[$report_status]['status_sql_where'];
+	$where .= ( $where <> '' ? " AND" : " WHERE" ) . " " . $mysqli->real_escape_string($dmarc_result[$report_status]['status_sql_where']);
 }
 
 // Domains

--- a/dmarcts-report-viewer-report-list.php
+++ b/dmarcts-report-viewer-report-list.php
@@ -272,10 +272,6 @@ FROM
 			SELECT
 				SUM(rcount) AS rcount,
 				serial,
-				dkim_align,
-				spf_align,
-				dkimresult,
-				spfresult,
 				MIN(
 					(CASE
 						WHEN dkim_align = 'fail' THEN 0
@@ -345,8 +341,6 @@ FROM
 	ON
 		report.serial = rptrecord.serial
 $where
-GROUP BY
-	serial
 ORDER BY
     " . $cookie_options['sort_column'] . ( $cookie_options['sort'] ? " ASC" : " DESC" )
 ;

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -219,7 +219,7 @@ include "dmarcts-report-viewer-common.php";
 // --------------------------------------------------------------------------
 configure();
 
-setcookie("dmarcts-options-tmp", "", "01 Jan 1970 00:00:00 UTC", "/");
+setcookie("dmarcts-options-tmp", "", time() - 3600, "/");
 
 // Make a MySQL Connection using mysqli
 // --------------------------------------------------------------------------


### PR DESCRIPTION
This update fixes the following Issues:

1. Potential SQL or security issue if `$_GET['rptstat']` and thus $report_status is malformed.
- This is in line with using real_escape_string() with the other GET variables.
2. Issue #67
- Fix for SQL Error 1055.
3. Issue #69
- Fix for type error in setcookie()