### PR TITLE
README: reference required package `php-xml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A PHP viewer for DMARC records that have been parsed by [John Levine's rddmarc s
 
 * A working webserver (apache, nginx, ...) with PHP
 
-* Installed `php-mysql` and `php-dom`
+* Installed `php-mysql` and `php-xml`
 
 ### Download dmarcts-report-viewer:
 ```


### PR DESCRIPTION
The required packages under Debian and Ubuntu are called `php-mysql` and `php-xml`. The mentioned `php-dom` might be an outdated reference (or a reference to another OS?).