### PR TITLE
Update dmarcts-report-viewer.php

### DIFF
--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -309,6 +309,19 @@ while($row = $query->fetch_assoc()) {
 	$periods[] = sprintf( "%'.04d-%'.02d", $row['year'], $row['month'] );
 }
 
+// When arrays of data do not exist, for example in a new & empty set-up, create empty arrays
+// --------------------------------------------------------------------------
+if(!isset($domains)){
+        $domains = array();
+}
+if(!isset($orgs)){
+        $orgs = array();
+}
+if(!isset($periods)){
+        $periods = array();
+}
+
+
 // Generate Page with report list and report data (if a report is selected).
 // --------------------------------------------------------------------------
 echo html(


### PR DESCRIPTION
When arrays of data do not exist, for example in a new & empty set-up, create empty arrays.

It shows just a white page, with following warnings and error:

```
Warning: Undefined variable $domains in /var/www/viewer/dmarcts-report-viewer.php on line 324
Warning: Undefined variable $orgs in /var/www/viewer/dmarcts-report-viewer.php on line 325
Warning: Undefined variable $periods in /var/www/viewer/dmarcts-report-viewer.php on line 326
Fatal error: Uncaught TypeError: count(): Argument #1 ($var) must be of type Countable|array, null given in /var/www/viewer/dmarcts-report-viewer.php:125 Stack trace: #0 /var/www/viewer/dmarcts-report-viewer.php(326): html() #1 {main} thrown in /var/www/viewer/dmarcts-report-viewer.php on line 125
```

My PR solves those, and gives a 'clean and empty' view of the DMARC Report Viewer.