### PR TITLE
XSS: Escape Raw HTML in Outputs

### DIFF
--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -55,7 +55,7 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 
 	if (isset($reports[$reportnumber])) {
 		$row = $reports[$reportnumber];
-		
+
 		$row['raw_xml'] = formatXML($row['raw_xml'], $reportnumber);
 		$row = array_map('html_escape', $row);
 

--- a/dmarcts-report-viewer-report-data.php
+++ b/dmarcts-report-viewer-report-data.php
@@ -55,8 +55,9 @@ function tmpl_reportData($reportnumber, $reports, $host_lookup = 1) {
 
 	if (isset($reports[$reportnumber])) {
 		$row = $reports[$reportnumber];
-
+		
 		$row['raw_xml'] = formatXML($row['raw_xml'], $reportnumber);
+		$row = array_map('html_escape', $row);
 
 		$reportdata[] = "<div id='report_desc_container' class='center reportdesc_container'>";
 		$reportdata[] = "<div id='report_desc' class='center reportdesc'  class='hilighted' onmouseover='highlight(this);' onmouseout='unhighlight(this);' onclick='pin(this)'>Report from ".$row['org']." for ".$row['domain']."<br>". format_date($row['mindate'], $cookie_options['date_format']). " to ".format_date($row['maxdate'], $cookie_options['date_format'])."<br> Policies: adkim=" . $row['policy_adkim'] . ", aspf=" . $row['policy_aspf'] .  ", p=" . $row['policy_p'] .  ", sp=" . $row['policy_sp'] .  ", pct=" . $row['policy_pct'] . "</div>";
@@ -151,7 +152,7 @@ ORDER BY
 		$row = array_map('html_escape', $row);
 
 		$reportdata[] = "    <tr id='line" . $row['id'] . "' class='" . get_dmarc_result($row)['color'] . "' title='DMARC Result: " . get_dmarc_result($row)['result'] . "'  onmouseover='highlight(this);' onmouseout='unhighlight(this);' onclick='pin(this);'>";
-		$reportdata[] = "      <td>". $ip. "</td>";
+		$reportdata[] = "      <td>". htmlspecialchars($ip) . "</td>";
 		if ( $host_lookup ) {
 			$reportdata[] = "      <td>". gethostbyaddr($ip). "</td>";
 		} else {

--- a/dmarcts-report-viewer.php
+++ b/dmarcts-report-viewer.php
@@ -148,7 +148,7 @@ function html ($domains = array(), $orgs = array(), $periods = array() ) {
 		$html[] = "<option " . ( $cookie_options['Domain'] ? "" : "selected=\"selected\" " ) . "value=\"all\">[all]</option>";
 
 		foreach( $domains as $d) {
-			$html[] = "<option " . ( $cookie_options['Domain'] == $d ? "selected=\"selected\" " : "" ) . "value=\"$d\">$d</option>";
+			$html[] = "<option " . ( $cookie_options['Domain'] == $d ? "selected=\"selected\" " : "" ) . "value=\"".htmlspecialchars($d)."\">".htmlspecialchars($d)."</option>";
 		}
 
 		$html[] = "</select>";
@@ -164,7 +164,7 @@ function html ($domains = array(), $orgs = array(), $periods = array() ) {
 		$html[] = "<option " . ( $cookie_options['Organisation'] ? "" : "selected=\"selected\" " ) . "selected=\"selected\" value=\"all\">[all]</option>";
 
 		foreach( $orgs as $o) {
-			$html[] = "<option " . ( $cookie_options['Organisation'] == $o ? "selected=\"selected\" " : "" ) . "value=\"$o\">" . ( strlen( $o ) > 25 ? substr( $o, 0, 22) . "..." : $o ) . "</option>";
+			$html[] = "<option " . ( $cookie_options['Organisation'] == $o ? "selected=\"selected\" " : "" ) . "value=\"".htmlspecialchars($o)."\">" . ( strlen( $o ) > 25 ? htmlspecialchars(substr( $o, 0, 22)) . "..." : htmlspecialchars($o) ) . "</option>";
 		}
 
 		$html[] = "</select>";


### PR DESCRIPTION
Resolve an issue where malicious XSS injected into the XML for `org_name` or `domain` values can anonymously target email admins accessing the PHP dashboard and execute arbitrary JavaScript remotely.

A technical exploration is available [on my blog](https://xmit.xyz/security/dmarcd-for-death/).